### PR TITLE
Fix: Redirect dump path to sandboxed tmp to resolve permission issues.

### DIFF
--- a/frida_ipa_extract/cli.py
+++ b/frida_ipa_extract/cli.py
@@ -283,7 +283,11 @@ def main():
         if not bundle_path or not executable_name:
             raise SystemExit("Unable to resolve bundle path or executable name.")
         dump_dir = bundle_id or sanitize_filename(app_name)
-        remote_dump_path = f"/tmp/frida-ipa-extract/{dump_dir}/{executable_name}.decrypted"
+        
+        sandbox_path = dumper.get_sandbox_path()
+        if not sandbox_path:
+            raise SystemExit("Unable to resolve sandbox path.")
+        remote_dump_path = f"{sandbox_path}/tmp/{dump_dir}/{executable_name}.decrypted"
 
         print(f"Bundle ID: {bundle_id or 'unknown'}")
         print(f"Bundle path: {bundle_path}")
@@ -296,9 +300,6 @@ def main():
         sandbox_path = None
         sandbox_out_dir = None
         if args.sandbox:
-            sandbox_path = dumper.get_sandbox_path()
-            if not sandbox_path:
-                raise SystemExit("Unable to resolve sandbox path.")
             sandbox_out_dir = f"{sanitize_filename(app_name)}-sandbox"
             if os.path.exists(sandbox_out_dir):
                 raise SystemExit(


### PR DESCRIPTION
# Description
- Issue: Original code writes to system root /tmp/, which causes Operation not permitted on iOS 16 due to sandbox restrictions.
- Fix: Moved get_sandbox_path() forward and redirected remote_dump_path to the app's internal /tmp/ directory.
- Result: Ensures the tool has write permissions to dump decrypted binaries on modern iOS.

# 说明
- 问题： 原代码尝试写入系统根目录 /tmp/，在 iOS 16 环境下因沙盒限制报错 Operation not permitted。
- 修复： 将 get_sandbox_path() 逻辑前置，并将 remote_dump_path 重定向至 App 沙盒内部的 /tmp/ 目录。
- 结果： 解决了现代 iOS 系统中解密文件写入失败的问题。